### PR TITLE
Fix (Docs): Switch "Router" to "Ranger" on docs page and issue template config file

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🤔 Feature Requests & Questions
-    url: https://github.com/tanstack/router/discussions
+    url: https://github.com/tanstack/ranger/discussions
     about: Please ask and answer questions here.
   - name: 💬 Community Chat
     url: https://discord.gg/mQd7egN

--- a/docs/adapters/react-ranger.md
+++ b/docs/adapters/react-ranger.md
@@ -1,8 +1,8 @@
 ---
-title: React Router
+title: React Ranger
 ---
 
-You can install TanStack Router with any [NPM](https://npmjs.com) package manager.
+You can install TanStack Ranger with any [NPM](https://npmjs.com) package manager.
 
 ```sh
 npm install @tanstack/react-ranger


### PR DESCRIPTION
These two files in the project had "Router" written down instead of "Ranger" 

https://tanstack.com/ranger/v1/docs/adapters/react-ranger

![Screenshot 2024-01-01 034053](https://github.com/TanStack/ranger/assets/100495707/c71c3946-0f1b-435e-b479-0fdcef92681e)

