### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/framework/react/api/basic.md
+++ b/docs/framework/react/api/basic.md
@@ -13,6 +13,7 @@ The API below describes how to use the **basic** features.
 
 ## Options
 
+
 ### values
 
 ```tsx
@@ -49,6 +50,7 @@ onChange: (instance: Ranger<TTrackElement>) => void
 A function that is called when the handle is released.
 
 ## API
+
 
 ### handles
 ```tsx

--- a/docs/framework/react/api/basic.md
+++ b/docs/framework/react/api/basic.md
@@ -9,7 +9,7 @@ Want to skip to the implementation? Check out these examples:
 
 - [basic](../../examples/react/basic)
 
-The API below described how to use the **basic** features.
+The API below describes how to use the **basic** features.
 
 ## Options
 


### PR DESCRIPTION
Changed "described" to "describes" and added more spacing after the H2's for Options and API to stop them from being on the same line.